### PR TITLE
refactored default env file

### DIFF
--- a/docker-compose/.env
+++ b/docker-compose/.env
@@ -1,2 +1,2 @@
-DOCKER_REGISTRY_HOST=docker.io
-DOCKER_REGISTRY_USER=tbd
+DOCKER_REGISTRY_HOST=registry.gitlab.com
+DOCKER_REGISTRY_USER=ska-telescope/ska-docker


### PR DESCRIPTION
The current default Makefile is not working with default .env settings.
In this new configuration I can docker login into gitlab and pull from the docker-compose folder, I suggest this to be the default configuration.
Also, when running this pull I get errors for POGO and STARTER images, and this shall be fixed in further updates.
We should include a test to check that the default docker-compose configuration is in a working status. 