### PR TITLE
Use docker executor and machine

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -104,6 +104,8 @@ test-framework-tangorest:
     - engageska
   script:
     - echo "******** Test Result ********" > result.txt
+    - docker exec apt-get update
+    - docker exec apt-get -y install curl
     - echo "docker exec tango-rest curl --user tango-cs:tango http://127.0.0.1:8080/tango/rest/rc4/hosts/databaseds/10000/devices/sys/tg_test/1/attributes/boolean_scalar/value" >> result.txt
     - docker exec tango-rest curl --user tango-cs:tango http://127.0.0.1:8080/tango/rest/rc4/hosts/databaseds/10000/devices/sys/tg_test/1/attributes/boolean_scalar/value >>  result.txt
     - more result.txt

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,17 +32,16 @@ before_script:
 build_tango-db:
   stage: build
   tags:
-    - docker-machine
+    - docker
   script: 
     - cd docker/tango/tango-db
     - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
-#    - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST push
-#  when: manual
+    - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST push
   
 test-framework-nomake:
   stage: test
-#  tags:
-#    - shell
+  tags:
+    - docker
   script:
     - cd docker-compose
     - docker-compose -f tango.yml -f tangotest.yml -f rest.yml pull
@@ -52,5 +51,4 @@ test-framework-nomake:
     - docker exec tangotest python3 /home/tango/SimpleTest.py
     - docker exec tangotest pytest -q /home/tango/SimplePyTest.py
     - curl --user tango-cs:tango http://127.0.0.1:8080/tango/rest/rc4/hosts/databaseds/10000/devices/sys/tg_test/1/attributes/boolean_scalar/value
-  when: manual
   

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 # GitLab CI in conjunction with GitLab Runner can use Docker Engine to test and build any application.
 # Docker, when used with GitLab CI, runs each job in a separate and isolated container using the predefined image that is set up in .gitlab-ci.yml.
 # In this case we use the latest python docker image to build and test this project.
-image: docker:latest
+image: registry.gitlab.com/ska-telescope/ska-docker/tango-dependencies:latest
 
 services:
   - docker:dind

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,7 +32,7 @@ before_script:
 build_tango-db:
   stage: build
   tags:
-    - docker
+    - docker-machine
   script: 
     - cd docker/tango/tango-db
     - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -136,9 +136,6 @@ start-framework:
     - make up 
     - make start tangotest
     - make start rest
-  artifacts:
-    paths:
-    - public 
     
 stop-framework:
   stage: stop-containers
@@ -150,9 +147,6 @@ stop-framework:
     - make stop tangotest
     - make stop rest
     - make down
-  artifacts:
-    paths:
-    - public 
   
 test-framework-tangotest:
   stage: test
@@ -187,7 +181,6 @@ test-framework-tangorest:
     - echo "docker exec tango-rest curl --user tango-cs:tango http://127.0.0.1:8080/tango/rest/rc4/hosts/databaseds/10000/devices/sys/tg_test/1/attributes/boolean_scalar/value" >> result.txt
     - docker exec tango-rest curl --user tango-cs:tango http://127.0.0.1:8080/tango/rest/rc4/hosts/databaseds/10000/devices/sys/tg_test/1/attributes/boolean_scalar/value >>  result.txt
     - more result.txt
-    - cd ..
     - mkdir .public
     - cp result.txt .public/result.txt
     - mv .public public

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,6 +33,7 @@ build_tango-db:
   stage: build
   tags:
     - docker
+    - engageska
   script: 
     - cd docker/tango/tango-db
     - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
@@ -42,6 +43,7 @@ test-framework-nomake:
   stage: test
   tags:
     - docker
+    - engageska
   script:
     - cd docker-compose
     - docker-compose -f tango.yml -f tangotest.yml -f rest.yml pull

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,9 +3,13 @@
 # In this case we use the latest python docker image to build and test this project.
 image: ubuntu:latest
 
+variables:
+  DOCKER_DRIVER: overlay
+
+
 services:
   - docker:dind
-
+  
 # During the development of software, there can be many stages until it's ready for public consumption. 
 # You sure want to first test your code and then deploy it in a testing or staging environment before you release it to the public. 
 # That way you can prevent bugs not only in your software, but in the deployment process as well. 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,7 +41,7 @@ build_dependencies:
   stage: build_1
   tags:
     - engageska
-    - docker-machine
+    - docker-executor
   script: 
     - cd docker/tango/tango-dependencies
     - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
@@ -52,37 +52,40 @@ build_tango-cpp:
   stage: build_2
   tags:
     - engageska 
-    - docker-machine    
+    - docker-executor    
   script: 
     - cd docker/tango/tango-cpp
     - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
     - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST push
- 
+  when: manual
+  
 build_tango-java:
   stage: build_2
   tags:
     - engageska 
-    - docker-machine
+    - docker-executor
   script: 
     - cd docker/tango/tango-java
     - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
     - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST push
-
+  when: manual
+  
 build_tango-python:
   stage: build_3
   tags:
     - engageska 
-    - docker-machine
+    - docker-executor
   script: 
     - cd docker/tango/tango-python
     - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
     - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST push
-
+  when: manual
+  
 build_tango-db:
   stage: build_1
   tags:
     - engageska
-    - docker-machine    
+    - docker-executor    
   script: 
     - cd docker/tango/tango-db
     - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
@@ -93,17 +96,18 @@ build_tango-rest:
   stage: build_3
   tags:
     - engageska
-    - docker-machine
+    - docker-executor
   script: 
     - cd docker/tango/tango-rest
     - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
     - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST push
-    
+  when: manual
+  
 build_tango-pogo:
   stage: build_3
   tags:
     - engageska
-    - docker-machine
+    - docker-executor
   script: 
     - cd docker/tango/tango-pogo
     - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
@@ -114,7 +118,7 @@ build_tango-starter:
   stage: build_3
   tags:
     - engageska 
-    - docker-machine
+    - docker-executor
   script: 
     - cd docker/tango/tango-starter
     - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
@@ -125,7 +129,7 @@ start-framework:
   stage: start-containers
   tags:
     - engageska
-    - docker-machine
+    - docker-executor
   script:
     - cd docker-compose
     - make pull
@@ -140,7 +144,7 @@ stop-framework:
   stage: stop-containers
   tags:
     - engageska
-    - docker-machine
+    - docker-executor
   script:
     - cd docker-compose
     - make stop tangotest
@@ -154,7 +158,7 @@ test-framework-tangotest:
   stage: test
   tags:
     - engageska
-    - docker-machine
+    - docker-executor
   script:
     - cd docker-compose
     - echo "******** Test Result ********" > result.txt
@@ -177,7 +181,7 @@ test-framework-tangorest:
   stage: test
   tags:
     - engageska
-    - docker-machine
+    - docker-executor
   script:
     - echo "******** Test Result ********" > result.txt
     - echo "docker exec tango-rest curl --user tango-cs:tango http://127.0.0.1:8080/tango/rest/rc4/hosts/databaseds/10000/devices/sys/tg_test/1/attributes/boolean_scalar/value" >> result.txt

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -48,6 +48,8 @@ test-framework-make:
   tags:
     - docker
     - engageska
+  services:
+  - $DOCKER_REGISTRY_HOST/$DOCKER_REGISTRY_USER/tango-rest:latest
   script:
     - cd docker-compose
     - make pull
@@ -77,6 +79,8 @@ test-framework-nomake:
   tags:
     - docker
     - engageska
+  services:
+  - $DOCKER_REGISTRY_HOST/$DOCKER_REGISTRY_USER/tango-rest:latest
   script:
     - cd docker-compose
     - docker-compose -f tango.yml -f tangotest.yml -f rest.yml pull

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,12 +16,18 @@ stages:
 
 #with shell executor, there is no need to install things. 
 before_script:
-  #- apt-get update
-  #- apt-get install make bash git curl
-  #- apt-get install -y python-pip
-  #- export LC_ALL=C
-  #- pip install docker-compose
-  #- pip install pytest
+  - apt-get update
+  - apt-get install make bash git curl
+  - apt-get install -y python-pip
+  - apt-get install apt-transport-https ca-certificates curl software-properties-common
+  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+  - apt-key fingerprint 0EBFCD88
+  - add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+  - apt-get update
+  - apt-get install docker-ce
+  - export LC_ALL=C
+  - pip install docker-compose
+  - pip install pytest
   - docker login -u "$CI_REGISTRY_USER" -p "$CI_REGISTRY_PASSWORD" $CI_REGISTRY
   - docker pull $DOCKER_REGISTRY_HOST/$DOCKER_REGISTRY_USER/tango-dependencies
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -79,8 +79,6 @@ test-framework-tangotest:
   tags:
     - docker
     - engageska
-  services:
-    - $DOCKER_REGISTRY_HOST/$DOCKER_REGISTRY_USER/tango-rest:latest
   script:
     - cd docker-compose
     - echo "******** Test Result ********" > result.txt
@@ -90,8 +88,6 @@ test-framework-tangotest:
     - docker exec tangotest python3 /home/tango/SimpleTest.py >> result.txt
     - echo "docker exec tangotest pytest -q /home/tango/SimplePyTest.py" >> result.txt
     - docker exec tangotest pytest -q /home/tango/SimplePyTest.py >> result.txt
-    - echo "curl --user tango-cs:tango http://127.0.0.1:8080/tango/rest/rc4/hosts/databaseds/10000/devices/sys/tg_test/1/attributes/boolean_scalar/value" >> result.txt
-    - curl --user tango-cs:tango http://127.0.0.1:8080/tango/rest/rc4/hosts/databaseds/10000/devices/sys/tg_test/1/attributes/boolean_scalar/value >>  result.txt
     - more result.txt
     - cd ..
     - mkdir .public
@@ -106,12 +102,10 @@ test-framework-tangorest:
   tags:
     - docker
     - engageska
-  services:
-  - $DOCKER_REGISTRY_HOST/$DOCKER_REGISTRY_USER/tango-rest:latest
   script:
     - echo "******** Test Result ********" > result.txt
-    - echo "curl --user tango-cs:tango http://127.0.0.1:8080/tango/rest/rc4/hosts/databaseds/10000/devices/sys/tg_test/1/attributes/boolean_scalar/value" >> result.txt
-    - curl --user tango-cs:tango http://127.0.0.1:8080/tango/rest/rc4/hosts/databaseds/10000/devices/sys/tg_test/1/attributes/boolean_scalar/value >>  result.txt
+    - echo "docker exec tango-rest curl --user tango-cs:tango http://127.0.0.1:8080/tango/rest/rc4/hosts/databaseds/10000/devices/sys/tg_test/1/attributes/boolean_scalar/value" >> result.txt
+    - docker exec tango-rest curl --user tango-cs:tango http://127.0.0.1:8080/tango/rest/rc4/hosts/databaseds/10000/devices/sys/tg_test/1/attributes/boolean_scalar/value >>  result.txt
     - more result.txt
     - cd ..
     - mkdir .public

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 # GitLab CI in conjunction with GitLab Runner can use Docker Engine to test and build any application.
 # Docker, when used with GitLab CI, runs each job in a separate and isolated container using the predefined image that is set up in .gitlab-ci.yml.
 # In this case we use the latest python docker image to build and test this project.
-image: registry.gitlab.com/ska-telescope/ska-docker/tango-dependencies:latest
+image: ubuntu:latest
 
 services:
   - docker:dind

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@ stages:
 before_script:
   - apt-get update
   - apt-get install -y make bash git curl python-pip apt-transport-https ca-certificates curl software-properties-common
-  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
   - apt-key fingerprint 0EBFCD88
   - add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
   - apt-get update
@@ -28,98 +28,16 @@ before_script:
   - pip install pytest
   - docker login -u "$CI_REGISTRY_USER" -p "$CI_REGISTRY_PASSWORD" $CI_REGISTRY
   - docker pull $DOCKER_REGISTRY_HOST/$DOCKER_REGISTRY_USER/tango-dependencies
-
-build_dependencies:
-  stage: build
-#  tags:
-#    - shell  
-  script: 
-    - cd docker/tango/tango-dependencies
-    - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
-    - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST push
-  when: manual
     
 build_tango-db:
   stage: build
-#  tags:
-#    - shell  
-
+  tags:
+    - docker
   script: 
     - cd docker/tango/tango-db
     - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
 #    - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST push
 #  when: manual
-  
-build_tango-cpp:
-  stage: build
-#  tags:
-#    - shell   
-  script: 
-    - cd docker/tango/tango-cpp
-    - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
-    - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST push
-  when: manual
- 
-build_tango-java:
-  stage: build
-#  tags:
-#    - shell  
-  script: 
-    - cd docker/tango/tango-java
-    - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
-    - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST push
-  when: manual
-
-build_tango-python:
-  stage: build
-#  tags:
-#    - shell 
-  script: 
-    - cd docker/tango/tango-python
-    - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
-    - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST push
-  when: manual
-    
-build_tango-rest:
-  stage: build
-#  tags:
-#    - shell  
-  script: 
-    - cd docker/tango/tango-rest
-    - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
-    - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST push
-  when: manual
-    
-build_tango-pogo:
-  stage: build
-#  tags:
-#    - shell  
-  script: 
-    - cd docker/tango/tango-pogo
-    - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
-    - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST push
-  when: manual
-
-build_tango-starter:
-  stage: build
-#  tags:
-#    - shell  
-  script: 
-    - cd docker/tango/tango-starter
-    - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
-    - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST push
-  when: manual
-
-build-all:
-  stage: build
-#  tags:
-#    - shell
-  script:
-    - ls -la
-    - cd docker
-    - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
-    - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST push
-  when: manual
   
 test-framework-nomake:
   stage: test
@@ -135,31 +53,4 @@ test-framework-nomake:
     - docker exec tangotest pytest -q /home/tango/SimplePyTest.py
     - curl --user tango-cs:tango http://127.0.0.1:8080/tango/rest/rc4/hosts/databaseds/10000/devices/sys/tg_test/1/attributes/boolean_scalar/value
   when: manual
-    
-test-framework-make:
-  stage: test
-#  tags:
-#    - shell
-  script:
-    - cd docker-compose
-    - make pull
-    - make up 
-    - make start tangotest
-    - make start rest
-    - echo "******** Test Result ********" > result.txt
-    - docker cp SimpleTest.py tangotest:/home/tango/SimpleTest.py 
-    - docker cp SimplePyTest.py tangotest:/home/tango/SimplePyTest.py 
-    - echo "docker exec tangotest python3 /home/tango/SimpleTest.py" >> result.txt
-    - docker exec tangotest python3 /home/tango/SimpleTest.py >> result.txt
-    - echo "docker exec tangotest pytest -q /home/tango/SimplePyTest.py" >> result.txt
-    - docker exec tangotest pytest -q /home/tango/SimplePyTest.py >> result.txt
-    - echo "curl --user tango-cs:tango http://127.0.0.1:8080/tango/rest/rc4/hosts/databaseds/10000/devices/sys/tg_test/1/attributes/boolean_scalar/value" >> result.txt
-    - curl --user tango-cs:tango http://127.0.0.1:8080/tango/rest/rc4/hosts/databaseds/10000/devices/sys/tg_test/1/attributes/boolean_scalar/value >>  result.txt
-    - more result.txt
-    - cd ..
-    - mkdir .public
-    - cp docker-compose/result.txt .public/result.txt
-    - mv .public public
-  artifacts:
-    paths:
-    - public
+  

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,7 +22,7 @@ stages:
   - test
   - stop-containers
 
-#with shell executor, there is no need to install things. 
+#with shell machine, there is no need to install things. 
 before_script:
   - apt-get update
   - apt-get install -y make bash git curl python-pip apt-transport-https ca-certificates curl software-properties-common
@@ -41,7 +41,7 @@ build_dependencies:
   stage: build_1
   tags:
     - engageska
-    - docker-executor
+    - docker-machine
   script: 
     - cd docker/tango/tango-dependencies
     - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
@@ -52,7 +52,7 @@ build_tango-cpp:
   stage: build_2
   tags:
     - engageska 
-    - docker-executor    
+    - docker-machine    
   script: 
     - cd docker/tango/tango-cpp
     - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
@@ -63,7 +63,7 @@ build_tango-java:
   stage: build_2
   tags:
     - engageska 
-    - docker-executor
+    - docker-machine
   script: 
     - cd docker/tango/tango-java
     - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
@@ -74,7 +74,7 @@ build_tango-python:
   stage: build_3
   tags:
     - engageska 
-    - docker-executor
+    - docker-machine
   script: 
     - cd docker/tango/tango-python
     - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
@@ -85,7 +85,7 @@ build_tango-db:
   stage: build_1
   tags:
     - engageska
-    - docker-executor    
+    - docker-machine    
   script: 
     - cd docker/tango/tango-db
     - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
@@ -96,7 +96,7 @@ build_tango-rest:
   stage: build_3
   tags:
     - engageska
-    - docker-executor
+    - docker-machine
   script: 
     - cd docker/tango/tango-rest
     - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
@@ -107,7 +107,7 @@ build_tango-pogo:
   stage: build_3
   tags:
     - engageska
-    - docker-executor
+    - docker-machine
   script: 
     - cd docker/tango/tango-pogo
     - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
@@ -118,7 +118,7 @@ build_tango-starter:
   stage: build_3
   tags:
     - engageska 
-    - docker-executor
+    - docker-machine
   script: 
     - cd docker/tango/tango-starter
     - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
@@ -129,7 +129,7 @@ start-framework:
   stage: start-containers
   tags:
     - engageska
-    - docker-executor
+    - docker-machine
   script:
     - cd docker-compose
     - make pull
@@ -141,7 +141,7 @@ stop-framework:
   stage: stop-containers
   tags:
     - engageska
-    - docker-executor
+    - docker-machine
   script:
     - cd docker-compose
     - make stop tangotest
@@ -152,7 +152,7 @@ test-framework-tangotest:
   stage: test
   tags:
     - engageska
-    - docker-executor
+    - docker-machine
   script:
     - cd docker-compose
     - echo "******** Test Result ********" > result.txt
@@ -175,7 +175,7 @@ test-framework-tangorest:
   stage: test
   tags:
     - engageska
-    - docker-executor
+    - docker-machine
   script:
     - echo "******** Test Result ********" > result.txt
     - echo "docker exec tango-rest curl --user tango-cs:tango http://127.0.0.1:8080/tango/rest/rc4/hosts/databaseds/10000/devices/sys/tg_test/1/attributes/boolean_scalar/value" >> result.txt

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -43,6 +43,35 @@ build_tango-db:
     - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
     - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST push
   
+test-framework-make:
+  stage: test
+  tags:
+    - docker
+    - engageska
+  script:
+    - cd docker-compose
+    - make pull
+    - make up 
+    - make start tangotest
+    - make start rest
+    - echo "******** Test Result ********" > result.txt
+    - docker cp SimpleTest.py tangotest:/home/tango/SimpleTest.py 
+    - docker cp SimplePyTest.py tangotest:/home/tango/SimplePyTest.py 
+    - echo "docker exec tangotest python3 /home/tango/SimpleTest.py" >> result.txt
+    - docker exec tangotest python3 /home/tango/SimpleTest.py >> result.txt
+    - echo "docker exec tangotest pytest -q /home/tango/SimplePyTest.py" >> result.txt
+    - docker exec tangotest pytest -q /home/tango/SimplePyTest.py >> result.txt
+    - echo "curl --user tango-cs:tango http://127.0.0.1:8080/tango/rest/rc4/hosts/databaseds/10000/devices/sys/tg_test/1/attributes/boolean_scalar/value" >> result.txt
+    - curl --user tango-cs:tango http://127.0.0.1:8080/tango/rest/rc4/hosts/databaseds/10000/devices/sys/tg_test/1/attributes/boolean_scalar/value >>  result.txt
+    - more result.txt
+    - cd ..
+    - mkdir .public
+    - cp docker-compose/result.txt .public/result.txt
+    - mv .public public
+  artifacts:
+    paths:
+    - public  
+
 test-framework-nomake:
   stage: test
   tags:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,14 +17,12 @@ stages:
 #with shell executor, there is no need to install things. 
 before_script:
   - apt-get update
-  - apt-get install make bash git curl
-  - apt-get install -y python-pip
-  - apt-get install apt-transport-https ca-certificates curl software-properties-common
+  - apt-get install -y make bash git curl python-pip apt-transport-https ca-certificates curl software-properties-common
   - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
   - apt-key fingerprint 0EBFCD88
   - add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
   - apt-get update
-  - apt-get install docker-ce
+  - apt-get install -y docker-ce
   - export LC_ALL=C
   - pip install docker-compose
   - pip install pytest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,7 +15,9 @@ services:
 # That way you can prevent bugs not only in your software, but in the deployment process as well. 
 # See also https://docs.gitlab.com/ee/ci/environments.html
 stages:
-  - build
+  - build_1
+  - build_2
+  - build_3
   - start-containers
   - test
   - stop-containers
@@ -36,7 +38,7 @@ before_script:
   - docker pull $DOCKER_REGISTRY_HOST/$DOCKER_REGISTRY_USER/tango-dependencies
 
 build_dependencies:
-  stage: build
+  stage: build_1
   tags:
     - engageska  
   script: 
@@ -44,9 +46,36 @@ build_dependencies:
     - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
     - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST push
   when: manual
-    
+  
+build_tango-cpp:
+  stage: build_2
+  tags:
+    - engageska  
+  script: 
+    - cd docker/tango/tango-cpp
+    - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
+    - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST push
+ 
+build_tango-java:
+  stage: build_2
+  tags:
+    - engageska 
+  script: 
+    - cd docker/tango/tango-java
+    - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
+    - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST push
+
+build_tango-python:
+  stage: build_3
+  tags:
+    - engageska 
+  script: 
+    - cd docker/tango/tango-python
+    - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
+    - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST push
+
 build_tango-db:
-  stage: build
+  stage: build_1
   tags:
     - engageska 
   script: 
@@ -54,49 +83,18 @@ build_tango-db:
     - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
     - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST push
   when: manual
-  
-build_tango-cpp:
-  stage: build
-  tags:
-    - engageska  
-  script: 
-    - cd docker/tango/tango-cpp
-    - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
-    - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST push
-  when: manual
- 
-build_tango-java:
-  stage: build
-  tags:
-    - engageska 
-  script: 
-    - cd docker/tango/tango-java
-    - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
-    - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST push
-  when: manual
-
-build_tango-python:
-  stage: build
-  tags:
-    - engageska 
-  script: 
-    - cd docker/tango/tango-python
-    - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
-    - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST push
-  when: manual
     
 build_tango-rest:
-  stage: build
+  stage: build_3
   tags:
     - engageska
   script: 
     - cd docker/tango/tango-rest
     - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
     - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST push
-  when: manual
     
 build_tango-pogo:
-  stage: build
+  stage: build_3
   tags:
     - engageska
   script: 
@@ -106,7 +104,7 @@ build_tango-pogo:
   when: manual
 
 build_tango-starter:
-  stage: build
+  stage: build_3
   tags:
     - engageska 
   script: 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,10 +1,10 @@
 # GitLab CI in conjunction with GitLab Runner can use Docker Engine to test and build any application.
 # Docker, when used with GitLab CI, runs each job in a separate and isolated container using the predefined image that is set up in .gitlab-ci.yml.
 # In this case we use the latest python docker image to build and test this project.
-#image: docker:latest
+image: docker:latest
 
-#services:
-#  - docker:dind
+services:
+  - docker:dind
 
 # During the development of software, there can be many stages until it's ready for public consumption. 
 # You sure want to first test your code and then deploy it in a testing or staging environment before you release it to the public. 
@@ -27,8 +27,8 @@ before_script:
 
 build_dependencies:
   stage: build
-  tags:
-    - shell  
+#  tags:
+#    - shell  
   script: 
     - cd docker/tango/tango-dependencies
     - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
@@ -37,18 +37,19 @@ build_dependencies:
     
 build_tango-db:
   stage: build
-  tags:
-    - shell  
+#  tags:
+#    - shell  
+
   script: 
     - cd docker/tango/tango-db
     - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
-    - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST push
-  when: manual
+#    - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST push
+#  when: manual
   
 build_tango-cpp:
   stage: build
-  tags:
-    - shell  
+#  tags:
+#    - shell   
   script: 
     - cd docker/tango/tango-cpp
     - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
@@ -57,8 +58,8 @@ build_tango-cpp:
  
 build_tango-java:
   stage: build
-  tags:
-    - shell  
+#  tags:
+#    - shell  
   script: 
     - cd docker/tango/tango-java
     - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
@@ -67,8 +68,8 @@ build_tango-java:
 
 build_tango-python:
   stage: build
-  tags:
-    - shell  
+#  tags:
+#    - shell 
   script: 
     - cd docker/tango/tango-python
     - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
@@ -77,8 +78,8 @@ build_tango-python:
     
 build_tango-rest:
   stage: build
-  tags:
-    - shell  
+#  tags:
+#    - shell  
   script: 
     - cd docker/tango/tango-rest
     - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
@@ -87,8 +88,8 @@ build_tango-rest:
     
 build_tango-pogo:
   stage: build
-  tags:
-    - shell  
+#  tags:
+#    - shell  
   script: 
     - cd docker/tango/tango-pogo
     - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
@@ -97,8 +98,8 @@ build_tango-pogo:
 
 build_tango-starter:
   stage: build
-  tags:
-    - shell  
+#  tags:
+#    - shell  
   script: 
     - cd docker/tango/tango-starter
     - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
@@ -107,8 +108,8 @@ build_tango-starter:
 
 build-all:
   stage: build
-  tags:
-    - shell
+#  tags:
+#    - shell
   script:
     - ls -la
     - cd docker
@@ -118,8 +119,8 @@ build-all:
   
 test-framework-nomake:
   stage: test
-  tags:
-    - shell
+#  tags:
+#    - shell
   script:
     - cd docker-compose
     - docker-compose -f tango.yml -f tangotest.yml -f rest.yml pull
@@ -133,8 +134,8 @@ test-framework-nomake:
     
 test-framework-make:
   stage: test
-  tags:
-    - shell
+#  tags:
+#    - shell
   script:
     - cd docker-compose
     - make pull

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,7 +16,9 @@ services:
 # See also https://docs.gitlab.com/ee/ci/environments.html
 stages:
   - build
+  - start-containers
   - test
+  - stop-containers
 
 #with shell executor, there is no need to install things. 
 before_script:
@@ -43,19 +45,44 @@ build_tango-db:
     - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
     - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST push
   
-test-framework-make:
-  stage: test
+start-framework:
+  stage: start-containers
   tags:
     - docker
     - engageska
-  services:
-  - $DOCKER_REGISTRY_HOST/$DOCKER_REGISTRY_USER/tango-rest:latest
   script:
     - cd docker-compose
     - make pull
     - make up 
     - make start tangotest
     - make start rest
+  artifacts:
+    paths:
+    - public 
+    
+stop-framework:
+  stage: stop-containers
+  tags:
+    - docker
+    - engageska
+  script:
+    - cd docker-compose
+    - make stop tangotest
+    - make stop rest
+    - make down
+  artifacts:
+    paths:
+    - public 
+  
+test-framework-tangotest:
+  stage: test
+  tags:
+    - docker
+    - engageska
+  services:
+    - $DOCKER_REGISTRY_HOST/$DOCKER_REGISTRY_USER/tango-rest:latest
+  script:
+    - cd docker-compose
     - echo "******** Test Result ********" > result.txt
     - docker cp SimpleTest.py tangotest:/home/tango/SimpleTest.py 
     - docker cp SimplePyTest.py tangotest:/home/tango/SimplePyTest.py 
@@ -73,8 +100,8 @@ test-framework-make:
   artifacts:
     paths:
     - public  
-
-test-framework-nomake:
+  
+test-framework-tangorest:
   stage: test
   tags:
     - docker
@@ -82,12 +109,15 @@ test-framework-nomake:
   services:
   - $DOCKER_REGISTRY_HOST/$DOCKER_REGISTRY_USER/tango-rest:latest
   script:
-    - cd docker-compose
-    - docker-compose -f tango.yml -f tangotest.yml -f rest.yml pull
-    - docker-compose -f tango.yml -f tangotest.yml -f rest.yml up -d 
-    - docker cp SimpleTest.py tangotest:/home/tango/SimpleTest.py
-    - docker cp SimplePyTest.py tangotest:/home/tango/SimplePyTest.py
-    - docker exec tangotest python3 /home/tango/SimpleTest.py
-    - docker exec tangotest pytest -q /home/tango/SimplePyTest.py
-    - curl --user tango-cs:tango http://127.0.0.1:8080/tango/rest/rc4/hosts/databaseds/10000/devices/sys/tg_test/1/attributes/boolean_scalar/value
+    - echo "******** Test Result ********" > result.txt
+    - echo "curl --user tango-cs:tango http://127.0.0.1:8080/tango/rest/rc4/hosts/databaseds/10000/devices/sys/tg_test/1/attributes/boolean_scalar/value" >> result.txt
+    - curl --user tango-cs:tango http://127.0.0.1:8080/tango/rest/rc4/hosts/databaseds/10000/devices/sys/tg_test/1/attributes/boolean_scalar/value >>  result.txt
+    - more result.txt
+    - cd ..
+    - mkdir .public
+    - cp ./result.txt .public/result.txt
+    - mv .public public
+  artifacts:
+    paths:
+    - public 
   

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -34,21 +34,90 @@ before_script:
   - pip install pytest
   - docker login -u "$CI_REGISTRY_USER" -p "$CI_REGISTRY_PASSWORD" $CI_REGISTRY
   - docker pull $DOCKER_REGISTRY_HOST/$DOCKER_REGISTRY_USER/tango-dependencies
+
+build_dependencies:
+  stage: build
+  tags:
+    - engageska  
+  script: 
+    - cd docker/tango/tango-dependencies
+    - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
+    - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST push
+  when: manual
     
 build_tango-db:
   stage: build
   tags:
-    - docker
-    - engageska
+    - engageska 
   script: 
     - cd docker/tango/tango-db
     - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
     - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST push
+  when: manual
   
+build_tango-cpp:
+  stage: build
+  tags:
+    - engageska  
+  script: 
+    - cd docker/tango/tango-cpp
+    - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
+    - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST push
+  when: manual
+ 
+build_tango-java:
+  stage: build
+  tags:
+    - engageska 
+  script: 
+    - cd docker/tango/tango-java
+    - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
+    - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST push
+  when: manual
+
+build_tango-python:
+  stage: build
+  tags:
+    - engageska 
+  script: 
+    - cd docker/tango/tango-python
+    - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
+    - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST push
+  when: manual
+    
+build_tango-rest:
+  stage: build
+  tags:
+    - engageska
+  script: 
+    - cd docker/tango/tango-rest
+    - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
+    - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST push
+  when: manual
+    
+build_tango-pogo:
+  stage: build
+  tags:
+    - engageska
+  script: 
+    - cd docker/tango/tango-pogo
+    - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
+    - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST push
+  when: manual
+
+build_tango-starter:
+  stage: build
+  tags:
+    - engageska 
+  script: 
+    - cd docker/tango/tango-starter
+    - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
+    - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST push
+  when: manual
+
 start-framework:
   stage: start-containers
   tags:
-    - docker
     - engageska
   script:
     - cd docker-compose
@@ -63,7 +132,6 @@ start-framework:
 stop-framework:
   stage: stop-containers
   tags:
-    - docker
     - engageska
   script:
     - cd docker-compose
@@ -77,7 +145,6 @@ stop-framework:
 test-framework-tangotest:
   stage: test
   tags:
-    - docker
     - engageska
   script:
     - cd docker-compose
@@ -100,12 +167,9 @@ test-framework-tangotest:
 test-framework-tangorest:
   stage: test
   tags:
-    - docker
     - engageska
   script:
     - echo "******** Test Result ********" > result.txt
-    - docker exec apt-get update
-    - docker exec apt-get -y install curl
     - echo "docker exec tango-rest curl --user tango-cs:tango http://127.0.0.1:8080/tango/rest/rc4/hosts/databaseds/10000/devices/sys/tg_test/1/attributes/boolean_scalar/value" >> result.txt
     - docker exec tango-rest curl --user tango-cs:tango http://127.0.0.1:8080/tango/rest/rc4/hosts/databaseds/10000/devices/sys/tg_test/1/attributes/boolean_scalar/value >>  result.txt
     - more result.txt

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,7 +40,8 @@ before_script:
 build_dependencies:
   stage: build_1
   tags:
-    - engageska  
+    - engageska
+    - docker-machine
   script: 
     - cd docker/tango/tango-dependencies
     - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
@@ -50,7 +51,8 @@ build_dependencies:
 build_tango-cpp:
   stage: build_2
   tags:
-    - engageska  
+    - engageska 
+    - docker-machine    
   script: 
     - cd docker/tango/tango-cpp
     - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
@@ -60,6 +62,7 @@ build_tango-java:
   stage: build_2
   tags:
     - engageska 
+    - docker-machine
   script: 
     - cd docker/tango/tango-java
     - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
@@ -69,6 +72,7 @@ build_tango-python:
   stage: build_3
   tags:
     - engageska 
+    - docker-machine
   script: 
     - cd docker/tango/tango-python
     - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
@@ -77,7 +81,8 @@ build_tango-python:
 build_tango-db:
   stage: build_1
   tags:
-    - engageska 
+    - engageska
+    - docker-machine    
   script: 
     - cd docker/tango/tango-db
     - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
@@ -88,6 +93,7 @@ build_tango-rest:
   stage: build_3
   tags:
     - engageska
+    - docker-machine
   script: 
     - cd docker/tango/tango-rest
     - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
@@ -97,6 +103,7 @@ build_tango-pogo:
   stage: build_3
   tags:
     - engageska
+    - docker-machine
   script: 
     - cd docker/tango/tango-pogo
     - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
@@ -107,6 +114,7 @@ build_tango-starter:
   stage: build_3
   tags:
     - engageska 
+    - docker-machine
   script: 
     - cd docker/tango/tango-starter
     - make DOCKER_REGISTRY_USER=$DOCKER_REGISTRY_USER DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST build
@@ -117,6 +125,7 @@ start-framework:
   stage: start-containers
   tags:
     - engageska
+    - docker-machine
   script:
     - cd docker-compose
     - make pull
@@ -131,6 +140,7 @@ stop-framework:
   stage: stop-containers
   tags:
     - engageska
+    - docker-machine
   script:
     - cd docker-compose
     - make stop tangotest
@@ -144,6 +154,7 @@ test-framework-tangotest:
   stage: test
   tags:
     - engageska
+    - docker-machine
   script:
     - cd docker-compose
     - echo "******** Test Result ********" > result.txt
@@ -166,6 +177,7 @@ test-framework-tangorest:
   stage: test
   tags:
     - engageska
+    - docker-machine
   script:
     - echo "******** Test Result ********" > result.txt
     - echo "docker exec tango-rest curl --user tango-cs:tango http://127.0.0.1:8080/tango/rest/rc4/hosts/databaseds/10000/devices/sys/tg_test/1/attributes/boolean_scalar/value" >> result.txt
@@ -173,7 +185,7 @@ test-framework-tangorest:
     - more result.txt
     - cd ..
     - mkdir .public
-    - cp ./result.txt .public/result.txt
+    - cp result.txt .public/result.txt
     - mv .public public
   artifacts:
     paths:

--- a/docker/tango/tango-rest/Dockerfile
+++ b/docker/tango/tango-rest/Dockerfile
@@ -17,8 +17,7 @@ RUN MTANGOREST_VERSION=rc4-2.10 \
     && rm -rf /var/lib/apt/lists/* \
     && mkdir /usr/local/lib/tango \
     && cd /usr/local/lib/tango \
-    && curl -fsSL "$MTANGOREST_DOWNLOAD_URL" -o mtangorest.jar \
-#    && apt-get purge -y --auto-remove $buildDeps
+    && curl -fsSL "$MTANGOREST_DOWNLOAD_URL" -o mtangorest.jar 
 
 COPY tango_register_device.sh /usr/local/bin/
 RUN chmod 755 /usr/local/bin/tango_register_device.sh

--- a/docker/tango/tango-rest/Dockerfile
+++ b/docker/tango/tango-rest/Dockerfile
@@ -18,7 +18,7 @@ RUN MTANGOREST_VERSION=rc4-2.10 \
     && mkdir /usr/local/lib/tango \
     && cd /usr/local/lib/tango \
     && curl -fsSL "$MTANGOREST_DOWNLOAD_URL" -o mtangorest.jar \
-    && apt-get purge -y --auto-remove $buildDeps
+#    && apt-get purge -y --auto-remove $buildDeps
 
 COPY tango_register_device.sh /usr/local/bin/
 RUN chmod 755 /usr/local/bin/tango_register_device.sh


### PR DESCRIPTION
I have improved the pipeline that now works both on docker-executor and docker-machine with autoscale mode (it creates up to 5 machine for testing and building simultaneously) . 
I have also made  a little change in the tango-rest dockerfile to install the "curl" that I use for testing purpose. 