### PR TITLE
new registry url

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,6 @@
 # GitLab CI in conjunction with GitLab Runner can use Docker Engine to test and build any application.
 # Docker, when used with GitLab CI, runs each job in a separate and isolated container using the predefined image that is set up in .gitlab-ci.yml.
-image: ska-registry.av.it.pt/ska-docker/tango-builder:latest
+image: nexus.engageska-portugal.pt/ska-docker/tango-builder:latest
 
 services:
 - docker:dind

--- a/docker-compose/.env
+++ b/docker-compose/.env
@@ -1,2 +1,2 @@
-DOCKER_REGISTRY_HOST=ska-registry.av.it.pt
+DOCKER_REGISTRY_HOST=nexus.engageska-portugal.pt
 DOCKER_REGISTRY_USER=ska-docker

--- a/docker/make/Makefile.mk
+++ b/docker/make/Makefile.mk
@@ -19,7 +19,7 @@ NAME=$(shell basename $(CURDIR))
 RELEASE_SUPPORT := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))/.make-release-support
 
 ifeq ($(strip $(DOCKER_REGISTRY_HOST)),)
-  DOCKER_REGISTRY_HOST = ska-registry.av.it.pt
+  DOCKER_REGISTRY_HOST = nexus.engageska-portugal.pt
 endif
 
 ifeq ($(strip $(DOCKER_REGISTRY_USER)),)


### PR DESCRIPTION
The docker registry has been migrated to the Nexus repository (nexus.engageska-portugal.pt) in order to have all repositories concentrated in one place. By that, ska-registry.av.it.pt will no longer be available.